### PR TITLE
Fix build output path + Authors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "jackettapi",
-  "version": "1.0.2",
+  "name": "@strdcoders/jackett-api",
+  "version": "1.0.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "jackettapi",
-      "version": "1.0.2",
+      "name": "@strdcoders/jackett-api",
+      "version": "1.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.27.2",
@@ -1663,6 +1663,39 @@
         "@vue/shared": "3.1.1"
       }
     },
+    "node_modules/@vue/reactivity": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.1.tgz",
+      "integrity": "sha512-DsH5woNVCcPK1M0RRYVgJEU1GJDU2ASOKpAqW3ppHk+XjoFLCbqc/26RTCgTpJYd9z8VN+79Q1u7/QqgQPbuLQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/shared": "3.1.1"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.1.1.tgz",
+      "integrity": "sha512-GboqR02txOtkd9F3Ysd8ltPL68vTCqIx2p/J52/gFtpgb5FG9hvOAPEwFUqxeEJRu7ResvQnmdOHiEycGPCLhQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/reactivity": "3.1.1",
+        "@vue/shared": "3.1.1"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.1.1.tgz",
+      "integrity": "sha512-o57n/199e/BBAmLRMSXmD2r12Old/h/gf6BgL0RON1NT2pwm6MWaMY4Ul55eyq+FsDILz4jR/UgoPQ9vYB8xcw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/runtime-core": "3.1.1",
+        "@vue/shared": "3.1.1",
+        "csstype": "^2.6.8"
+      }
+    },
     "node_modules/@vue/shared": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.1.tgz",
@@ -2274,6 +2307,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "3.2.7",
@@ -5774,6 +5814,18 @@
       "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
     },
+    "node_modules/vue": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.1.1.tgz",
+      "integrity": "sha512-j9fj3PNPMxo2eqOKYjMuss9XBS8ZtmczLY3kPvjcp9d3DbhyNqLYbaMQH18+1pDIzzVvQCQBvIf774LsjjqSKA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.1.1",
+        "@vue/runtime-dom": "3.1.1",
+        "@vue/shared": "3.1.1"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7357,6 +7409,36 @@
         "@vue/shared": "3.1.1"
       }
     },
+    "@vue/reactivity": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.1.1.tgz",
+      "integrity": "sha512-DsH5woNVCcPK1M0RRYVgJEU1GJDU2ASOKpAqW3ppHk+XjoFLCbqc/26RTCgTpJYd9z8VN+79Q1u7/QqgQPbuLQ==",
+      "peer": true,
+      "requires": {
+        "@vue/shared": "3.1.1"
+      }
+    },
+    "@vue/runtime-core": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.1.1.tgz",
+      "integrity": "sha512-GboqR02txOtkd9F3Ysd8ltPL68vTCqIx2p/J52/gFtpgb5FG9hvOAPEwFUqxeEJRu7ResvQnmdOHiEycGPCLhQ==",
+      "peer": true,
+      "requires": {
+        "@vue/reactivity": "3.1.1",
+        "@vue/shared": "3.1.1"
+      }
+    },
+    "@vue/runtime-dom": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.1.1.tgz",
+      "integrity": "sha512-o57n/199e/BBAmLRMSXmD2r12Old/h/gf6BgL0RON1NT2pwm6MWaMY4Ul55eyq+FsDILz4jR/UgoPQ9vYB8xcw==",
+      "peer": true,
+      "requires": {
+        "@vue/runtime-core": "3.1.1",
+        "@vue/shared": "3.1.1",
+        "csstype": "^2.6.8"
+      }
+    },
     "@vue/shared": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.1.1.tgz",
@@ -7836,6 +7918,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
+    },
+    "csstype": {
+      "version": "2.6.21",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.21.tgz",
+      "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w==",
+      "peer": true
     },
     "debug": {
       "version": "3.2.7",
@@ -10412,6 +10500,17 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
       "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
+    },
+    "vue": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.1.1.tgz",
+      "integrity": "sha512-j9fj3PNPMxo2eqOKYjMuss9XBS8ZtmczLY3kPvjcp9d3DbhyNqLYbaMQH18+1pDIzzVvQCQBvIf774LsjjqSKA==",
+      "peer": true,
+      "requires": {
+        "@vue/compiler-dom": "3.1.1",
+        "@vue/runtime-dom": "3.1.1",
+        "@vue/shared": "3.1.1"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@strdcoders/jackett-api",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "An api for 'Jackett' server requests",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build": "tsc -sourcemap -p ./tsconfig.json",
-    "run": "node -r source-map-support/register dist/src/index.js",
+    "run": "node -r source-map-support/register dist/index.js",
     "start": "npm run build && npm run run",
     "test": "nyc mocha -r ts-node/register test/**/*.spec.ts --exit",
     "depcheck": "depcheck --ignores \"source-map-support,ts-node,@types/chai-http,prettier,pretty-quick,eslint-plugin-jsdoc\"",
@@ -28,7 +28,21 @@
     "radarr",
     "plex"
   ],
-  "author": "STRDcoders",
+  "contributors": [
+    {
+      "name": "STRDcoders",
+      "url": "https://github.com/STRDCoders"
+    },
+    {
+      "name": "tomerblecher",
+      "url": "https://github.com/tomerblecher"
+    },
+    {
+      "name": "AirplaneGobrr",
+      "email": "airplane@airplanegobrr.xyz",
+      "url": "https://airplanegobrr.xyz"
+    }
+  ],
   "license": "Apache-2.0",
   "dependencies": {
     "axios": "^0.27.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es2017",
-    "outDir": "./dist/src",
+    "outDir": "./dist",
     "sourceMap": true,
     "removeComments": false,
     "declaration": true


### PR DESCRIPTION
Fixes #219

In the `package.json` the main file is set to `dist/index.js` however the `tsconfig.json`, `outDir` was set to `./dist/src`

This means when the files were built, they were put in `dist/src/index.js`, this leads to the `package.json` file not finding the main file, as well as the ts types!

This PR sets the `outDir` to `./dist`, removing `src` from the path, it also fixes the now broken `run` script, as well as it adds the authors to the `package.json` file

I've removed `src` from the `dist` as it doesn't make sense to have the `source` dir inside the `distributed` dir

This is one of the only jackett apis for nodejs and it would be nice to see it more active (mainly package updates that dependabot is making)